### PR TITLE
own firmware from local webserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM alpine
+#copy from cruftlab/mongoose-os-docker
+MAINTAINER Morten Aasbak loket@cruftlab.io
+
+# Install mos tool dependencies
+RUN apk add --no-cache curl
+
+# Install mos tool
+ADD https://mongoose-os.com/downloads/mos/install.sh /tmp/install-mos.sh
+RUN sh /tmp/install-mos.sh
+
+# Add volume and workdir
+VOLUME /sources/
+WORKDIR /sources/
+
+# Set entrypoint
+ENTRYPOINT ["/root/.mos/bin/mos"]
+
+# docker build -t mos .
+# docker run --rm -it -v $PWD:/sources mos build --build-var MODEL=$model --build-var TARGETFW=url TARGETURL=http://localhost --platform esp8266

--- a/mos.yml
+++ b/mos.yml
@@ -34,6 +34,10 @@ libs:
   - origin: https://github.com/mongoose-os-libs/ota-http-server         # local OTA update via HTTP POST
 
 conds:
+  - when: build_vars.TARGETFW == "url"
+    apply:
+      config_schema:
+        - ["mg2x.url", "s", "<HOST or IP>:8000/ota.bin" , {"title": "URL of target firmware"}]
   - when: build_vars.TARGETFW == "tasmota"
     apply:
       config_schema:

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,30 @@
+## Build the docker image
+Run the following commad to build the docker image with the tag mos
+```
+docker build -t mos .
+```
+
+## Build update firmware
+In the mos.yml replace <HOSTNAME OR IP> with the IP or HOSTNAME of your webserver.
+```yaml
+- when: build_vars.TARGETFW == "url"
+    apply:
+      config_schema:
+        - ["mg2x.url", "s", "<HOSTNAME OR IP>:8000/ota.bin" , {"title": "URL of target firmware"}]
+
+```
+To build the firmware run the following command via docker.
+ ```
+ docker run --rm -it -v $PWD:/sources mos build --build-var MODEL=Shelly25 --build-var TARGETFW=url --platform esp8266
+ ```
+It will result in a file build/fw.zip. This needs to be copied to the webserver directory e.g. server/fw.zip.
+
+## Start the python webserver
+First place your firmware as server/ota.bin in the webserver directory. To start the python webserver run the following command.
+```
+cd server/
+python3 -m http.server 8000
+```
+
+## Run the update on your shelly device
+Call your device from the webbrowser with the update url http://<IP of the shelly>/ota?url=http://<HOSTNAME OR IP>:8000/fw.zip. Replace <IP of the shelly> with the IP of your shelly device and <HOSTNAME OR IP> with the dns name or IP of your webserver.


### PR DESCRIPTION
I'm using esphome and want to directly switch to it without the need to go over tasmota.

With my changes there is a docker based way to build your own firmware to switch to any firmware which is served by an webserver in your local network. I'm using python for this job.

More details you will find in the attached readme.md.